### PR TITLE
Change alt tags to title tags for executive photos

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,7 +1,7 @@
 <html>
   <head>
     <title>Brock University Computer Science Club</title>
-    
+
     <!-- Insert All Favicon Links -->
     <link rel="apple-touch-icon" sizes="57x57" href="/apple-touch-icon-57x57.png">
     <link rel="apple-touch-icon" sizes="114x114" href="/apple-touch-icon-114x114.png">
@@ -18,7 +18,7 @@
     <link rel="icon" type="image/png" href="/favicon-32x32.png" sizes="32x32">
     <meta name="msapplication-TileColor" content="#cc0000">
     <meta name="msapplication-TileImage" content="/mstile-144x144.png">
-    
+
     <!-- Insert Meta Data -->
     <meta charset="utf-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
@@ -35,18 +35,18 @@
     <link rel="image_src" href="http://www.brockcsc.ca/img/logo.png" />
     <meta itemprop="image" content="http://www.brockcsc.ca/img/logo.png" />
     <meta name="description" content="Welcome to the Brock University Computer Science Club!" />
-    
+
     <!-- Insert CSS Files -->
     <link href='http://fonts.googleapis.com/css?family=Ubuntu:400,500,700|Oxygen' rel='stylesheet' type='text/css' />
     <link href="http://maxcdn.bootstrapcdn.com/font-awesome/4.2.0/css/font-awesome.min.css" rel="stylesheet" />
     <link href="css/style.css" rel="stylesheet" />
-    
+
     <!-- Insert Javascript -->
     <script type="text/javascript" src="http://code.jquery.com/jquery-1.11.1.min.js"></script>
     <script type="text/javascript" src="http://code.jquery.com/ui/1.11.1/jquery-ui.min.js"></script>
     <script type="text/javascript" src="js/script.js"></script>
   </head>
-  
+
   <body>
     <nav class="menu">
       <ul>
@@ -56,11 +56,11 @@
         <li><a href="#footer">Contact</a></li>
       </ul>
     </nav>
-  
+
     <div id="title-page" class="clearfix">
       <div class="title-wrapper">
         <h1>Brock University</h1>
-        <img src="img/logo.png" width="270" height="220" alt="CSC Logo alone in white." />
+        <img src="img/logo.png" width="270" height="220" alt="Logo of the Computer Science Club" />
         <h1>Computer Science Club</h1>
       </div>
       <div class="space"></div>
@@ -68,7 +68,7 @@
         <img id="arrow" src="img/arrow.png" alt="A bouncy arrow" />
       </a>
     </div>
-    
+
     <div id="about" class="clearfix">
       <div class="blurb">
         <h2>About Us</h2>
@@ -81,13 +81,13 @@
       <div class="gallery">
         <h2>Executives</h2>
 	<span>
-          <img src="img/james.JPG" width="250" height="315" alt="James is a coffee-fueled programming enthusiast in the 5th year of his degree in both Computer Science and Economics." />
+          <img src="img/james.JPG" width="250" height="315" title="James is a coffee-fueled programming enthusiast in the 5th year of his degree in both Computer Science and Economics." />
           <h3>James Earle</h3>
           <h4>President</h4>
         </span>
 	<br />
 	<span>
-          <img src="img/preston.png" width="250" height="315" alt="Preston is a fourth year Computer Science Co-op student and has been involved with the CSC for as many years. His primary function on campus is to think about how interested he is in AI and machine learning, and promptly play video games in the office instead." />
+          <img src="img/preston.png" width="250" height="315" title="Preston is a fourth year Computer Science Co-op student and has been involved with the CSC for as many years. His primary function on campus is to think about how interested he is in AI and machine learning, and promptly play video games in the office instead." />
           <h3>Preston Engstrom</h3>
           <h4>Executibe</h4>
         </span>
@@ -97,7 +97,7 @@
           <h4>Executive</h4>
         </span>
         <span>
-          <img src="img/riley.png" width="250" height="315" alt="If you were to ask others to describe me in a word, the most common reply would likely be passionate. I have a keen interest in technology, from the art of programming to the possibilities inherent in artificial intelligence. I’m currently in my fourth year of computer science (co-op) at Brock University. Having completed three co-op terms at RBC and John Deere, I have gained a good grasp on real-world programing and various programming methodologies." />
+          <img src="img/riley.png" width="250" height="315" title="If you were to ask others to describe me in a word, the most common reply would likely be passionate. I have a keen interest in technology, from the art of programming to the possibilities inherent in artificial intelligence. I’m currently in my fourth year of computer science (co-op) at Brock University. Having completed three co-op terms at RBC and John Deere, I have gained a good grasp on real-world programing and various programming methodologies." />
           <h3>Riley Davidson</h3>
           <h4>Executive</h4>
         </span>
@@ -113,7 +113,7 @@
           <h4>Executive</h4>
         </span>
         <span>
-          <img src="img/tyler.png" width="250" height="315" alt="Tell it like it is Tyler, Math Tyler, Grumpy Tyler." />
+          <img src="img/tyler.png" width="250" height="315" title="Tell it like it is Tyler, Math Tyler, Grumpy Tyler." />
           <h3>Tyler Collins</h3>
           <h4>Executive</h4>
         </span>
@@ -121,7 +121,7 @@
       <hr />
       <a class="top" href="#title-page"><h3><i class="fa fa-arrow-up"></i> Top</h3></a>
     </div>
-    
+
     <div id="services" class=clearfix>
       <div class="blurb">
         <h2>Our Services</h2>
@@ -168,9 +168,9 @@
         <a class="top" href="#title-page"><h3><i class="fa fa-arrow-up"></i> Top</h3></a>
       </div>
     </div>
-    
+
     <img id="jblock" src="img/Jblock.png" />
-    
+
     <div id="events" class="clearfix">
       <div class="blurb">
         <h2>Our Events</h2>
@@ -183,7 +183,7 @@
       <hr />
       <a class="top" href="#title-page"><h3><i class="fa fa-arrow-up"></i> Top</h3></a>
     </div>
-    
+
     <div id="footer">
       <h1>
         <a id="register" class="linkit" href="https://docs.google.com/forms/d/1OYhLSzrTrCPkKi1G1UlrB--KejPGR8Beg9G24ISLa8A/viewform?usp=send_form">Join the CSC</a>


### PR DESCRIPTION
I assume that the text for the photos was meant to show up as a tooltip, instead of alternative descriptions of the photos when they cannot be displayed. If that isn't the case, you can close this PR.