### PR TITLE
Implement #84: Custom dates, hidden date

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,5 @@ Thumbs.db
 # Firebase
 firebase-debug.log
 .firebase
+
+*.log

--- a/debug.log
+++ b/debug.log
@@ -1,0 +1,2 @@
+[1113/103803.875:ERROR:directory_reader_win.cc(43)] FindFirstFile: The system cannot find the path specified. (0x3)
+[0113/211705.878:ERROR:directory_reader_win.cc(43)] FindFirstFile: The system cannot find the path specified. (0x3)

--- a/debug.log
+++ b/debug.log
@@ -1,2 +1,0 @@
-[1113/103803.875:ERROR:directory_reader_win.cc(43)] FindFirstFile: The system cannot find the path specified. (0x3)
-[0113/211705.878:ERROR:directory_reader_win.cc(43)] FindFirstFile: The system cannot find the path specified. (0x3)

--- a/src/app/admin/events/add-edit-modal.component.html
+++ b/src/app/admin/events/add-edit-modal.component.html
@@ -46,8 +46,20 @@
           </div>
           <div class="row">
             <csc-checkbox class="col-12" label="Tentative date">
-              <input type="checkbox" formControlName="tentative" />>
+              <input type="checkbox" formControlName="tentative" />
             </csc-checkbox>
+          </div>
+          <div class="row">
+            <csc-checkbox class="col-12" label="Hidden/custom date">
+              <input type="checkbox" formControlName="hiddenDate" />
+            </csc-checkbox>
+            <input
+              [hidden]="!form.value.hiddenDate"
+              class="csc-input"
+              type="text"
+              formControlName="customDate"
+              placeholder="Every Tuesday at 3:30 PM"
+            />
           </div>
           <div class="row" formGroupName="datetime">
             <csc-input-container label="Date" class="col-4" labelLocation="top">

--- a/src/app/admin/events/add-modal/add-modal.component.ts
+++ b/src/app/admin/events/add-modal/add-modal.component.ts
@@ -43,6 +43,8 @@ export class AddModalComponent implements OnInit {
       gallery: new FormControl([]),
       tentative: false,
       dscEvent: false,
+      hiddenDate: false,
+      customDate: '',
     });
   }
 

--- a/src/app/admin/events/edit-modal/edit-modal.component.ts
+++ b/src/app/admin/events/edit-modal/edit-modal.component.ts
@@ -61,6 +61,8 @@ export class EditModalComponent implements OnInit {
       gallery: new FormControl([]),
       tentative: false,
       dscEvent: false,
+      hiddenDate: false,
+      customDate: '',
     });
   }
 

--- a/src/app/shared/api/event/event.ts
+++ b/src/app/shared/api/event/event.ts
@@ -20,4 +20,6 @@ export class CscEvent {
   googleFormUrl: string;
   tentative: boolean;
   dscEvent: boolean;
+  hiddenDate: boolean;
+  customDate: string;
 }

--- a/src/app/shared/event-card/event-card.component.html
+++ b/src/app/shared/event-card/event-card.component.html
@@ -19,11 +19,16 @@
       <span class="next-tag" *ngIf="next">UPCOMING EVENT</span>
     </div>
     <mat-card-subtitle>
-      {{ event.tentative ? '[TENTATIVE] ' : ''
-      }}{{ event.datetime.date | date }},
-      {{ event.datetime.timeStartTimestamp | date: 'hh:mm a' }} -
-      {{ event.datetime.timeEndTimestamp | date: 'hh:mm a' }}</mat-card-subtitle
-    >
+      {{ event.tentative ? '[TENTATIVE] ' : '' }}
+      <ng-container *ngIf="!event.hiddenDate">
+        {{ event.datetime.date | date }},
+        {{ event.datetime.timeStartTimestamp | date: 'hh:mm a' }} -
+        {{ event.datetime.timeEndTimestamp | date: 'hh:mm a' }}
+      </ng-container>
+      <ng-container *ngIf="event.hiddenDate && event.customDate">
+        {{ event.customDate }}
+      </ng-container>
+    </mat-card-subtitle>
     <mat-card-title>{{ event.title }}</mat-card-title>
   </mat-card>
 </a>


### PR DESCRIPTION
# Changes 🛠

Ability to have events with custom dates. New boolean for hidden/custom date while creating event, and optionally the ability to specify value for the custom date. Uses: things like repeating events like the weekly contest

# Testing 🧪

Changes from the latest PR are deployed to https://brockcsc-pr.web.app once the checks are complete. Can use this for testing.

### Any other info neededed for testing?

NO
