### PR TITLE
Fix hyperlinks in CS Guide

### DIFF
--- a/src/assets/cs-guide.md
+++ b/src/assets/cs-guide.md
@@ -58,7 +58,7 @@ N - 0 Credit (only required for co-op)
 
 https://brocku.ca/webcal/current/undergrad/areg.html#sec28
 
-Note: this should be cross referenced with the [https://brocku.ca/guides-and-timetables/timetables/?session=fw&type=ug&level=all](undergraduate timetable), as sometimes the courses listed here are not always offered.
+Note: this should be cross referenced with the [undergraduate timetable](https://brocku.ca/guides-and-timetables/timetables/?session=fw&type=ug&level=all), as sometimes the courses listed here are not always offered.
 
 ## Minor in Applied Computing
 

--- a/src/assets/cs-guide.md
+++ b/src/assets/cs-guide.md
@@ -115,7 +115,7 @@ We also have an unofficial graduation calculation Excel spreadsheet where you ca
 
 ## School Resources
 
-- [List of different degrees and specializations in Computer Science with their course requirements](https://brocku.ca/webcal/2020/undergrad/cosc.html)
+- [List of different degrees and specializations in Computer Science with their course requirements](https://brocku.ca/webcal/current/undergrad/cosc.html)
 - [Computer Science Department website](https://cosc.brocku.ca)
 
 # Goodies


### PR DESCRIPTION
# Changes 🛠

## What does this PR do?
1. Update the course calendar link in CS Guide to point to current computer science online calendar
2. Fix syntax for markdown hyperlink

## Screenshots 🖼

### Before
![image](https://user-images.githubusercontent.com/49620086/213028120-4046a8d6-3ffb-4c27-bc7b-bc4c6c91100c.png)

### After
![image](https://user-images.githubusercontent.com/49620086/213028137-034e6df1-8ce9-4bf8-a325-bed5241013cf.png)

## Any new npm dependencies?

NO

# Testing 🧪

Changes from the latest PR are deployed to https://brockcsc-pr.web.app once the checks are complete. Can use this for testing.

### Any other info needed for testing?

NO
