### PR TITLE
Refactor sass `/` operator to `math.div`

### DIFF
--- a/src/app/core/nav/hamburger/_base.scss
+++ b/src/app/core/nav/hamburger/_base.scss
@@ -1,5 +1,7 @@
 // Hamburger
 // ==================================================
+@use 'sass:math';
+
 .hamburger {
   padding: $hamburger-padding-y $hamburger-padding-x;
   display: inline-block;
@@ -38,7 +40,7 @@
 .hamburger-inner {
   display: block;
   top: 50%;
-  margin-top: $hamburger-layer-height / -2;
+  margin-top: math.div($hamburger-layer-height, -2);
 
   &,
   &::before,

--- a/src/styles/_grid.scss
+++ b/src/styles/_grid.scss
@@ -1,3 +1,5 @@
+@use 'sass:math';
+
 $width: 100%;
 
 .row {
@@ -29,7 +31,7 @@ $width: 100%;
 @media #{$desktop} {
   @for $i from 1 through 12 {
     .col-#{$i} {
-      width: $width / (12 / $i);
+      width: math.div($width, math.div(12, $i));
     }
   }
 }
@@ -37,7 +39,7 @@ $width: 100%;
 @media #{$tablet} {
   @for $i from 1 through 12 {
     .col-m-#{$i} {
-      width: $width / (12 / $i);
+      width: math.div($width, math.div(12, $i));
     }
   }
 }


### PR DESCRIPTION
# Changes 🛠

## What does this PR do?
Sass `/` operator for division is deprecated.
Used the [automatic migration tool](https://sass-lang.com/documentation/breaking-changes/slash-div#automatic-migration) to replace all occurrences of the `/` operator for division to `math.div`.
As a result, this also removes the pesky deprecation warnings during development.

## Screenshots 🖼
No UI changes

<!-- ### Before -->

<!-- ### After -->

## Any new npm dependencies?

NO

# Testing 🧪

Changes from the latest PR are deployed to https://brockcsc-pr.web.app once the checks are complete. Can use this for testing.

### Any other info needed for testing?

NO
