### PR TITLE
feat: collect applicant's current year in exec application form

### DIFF
--- a/src/app/views/exec-applications/execapplications.component.html
+++ b/src/app/views/exec-applications/execapplications.component.html
@@ -53,6 +53,30 @@
         </csc-input-container>
         <csc-input-container
           class="col-12"
+          label="Current year"
+          labelLocation="top"
+        >
+          <select
+            [name]="googleForm.ids.currentYear"
+            formControlName="currentYear"
+          >
+            <option value="1st year">1st year</option>
+            <option value="2nd year">2nd year</option>
+            <option value="3rd year">3rd year</option>
+            <option value="4th year">4th year</option>
+            <option value="5th+ year">5th+ year</option>
+          </select>
+          <span
+            class="signup-error"
+            *ngIf="
+              !form.controls.currentYear.valid &&
+              (form.controls.currentYear.touched || submitted)
+            "
+            >*Required</span
+          >
+        </csc-input-container>
+        <csc-input-container
+          class="col-12"
           label="Years of being an active participant in CSC events and groups"
           labelLocation="top"
         >

--- a/src/app/views/exec-applications/execapplications.component.ts
+++ b/src/app/views/exec-applications/execapplications.component.ts
@@ -21,6 +21,7 @@ export class ExecApplicationsComponent {
       skills: ['', Validators.required],
       workshop: ['', Validators.required],
       years: ['', Validators.required],
+      currentYear: ['', Validators.required],
     });
 
     this.submitted = false;
@@ -34,6 +35,7 @@ export class ExecApplicationsComponent {
         skills: 'entry.39093058',
         workshop: 'entry.22914651',
         years: 'entry.147287492',
+        currentYear: 'entry.1353896723',
       },
     };
   }
@@ -56,5 +58,6 @@ class GoogleFormConfig {
     skills: string;
     workshop: string;
     years: string;
+    currentYear: string;
   };
 }


### PR DESCRIPTION
# Changes 🛠

## What does this PR do?
Includes a field in the Exec Application form for the current year of the applicant.

## Screenshots 🖼

### Before
<img width="1056" alt="Screenshot 2023-09-27 at 10 34 22 PM" src="https://github.com/BrockCSC/brockcsc.github.io/assets/49620086/ff4fab6d-ede9-484b-973d-f17b79c8afed">

### After
<img width="1056" alt="Screenshot 2023-09-27 at 10 33 12 PM" src="https://github.com/BrockCSC/brockcsc.github.io/assets/49620086/a53c00d5-f297-4f3f-8dbb-74a918e24ba6">

## Any new npm dependencies?

NO

# Testing 🧪

Changes from the latest PR are deployed to https://brockcsc-pr.web.app once the checks are complete. Can use this for testing.

### Any other info needed for testing?

NO
