### PR TITLE
Remove exec-application tab

### DIFF
--- a/.github/workflows/brockcsc-test-deploy.yml
+++ b/.github/workflows/brockcsc-test-deploy.yml
@@ -33,7 +33,7 @@ jobs:
           name: dist
           path: dist
       - name: Deploy to Firebase
-        uses: w9jds/firebase-action@master
+        uses: w9jds/firebase-action@v13.4.0
         with:
           args: deploy --only hosting:brockcsc-test
         env:

--- a/.github/workflows/development-pr-test.yml
+++ b/.github/workflows/development-pr-test.yml
@@ -33,7 +33,7 @@ jobs:
           name: dist
           path: dist
       - name: Deploy to Firebase
-        uses: w9jds/firebase-action@master
+        uses: w9jds/firebase-action@v13.4.0
         with:
           args: deploy --only hosting:brockcsc-pr
         env:

--- a/src/app/app.router.ts
+++ b/src/app/app.router.ts
@@ -41,7 +41,7 @@ const routes: Routes = [
     loadChildren: () =>
       import('app/views/events/events.module').then((m) => m.EventsModule),
   },
-  { path: 'exec-application', component: ExecApplicationsComponent },
+  // { path: 'exec-application', component: ExecApplicationsComponent },
   { path: '**', redirectTo: 'home' },
 ];
 

--- a/src/app/core/nav/nav.component.ts
+++ b/src/app/core/nav/nav.component.ts
@@ -46,10 +46,10 @@ export class NavComponent implements OnInit {
       href: '/guide',
       desc: 'CS Guide',
     },
-    {
-      href: '/exec-application',
-      desc: 'Exec Application',
-    },
+    // {
+    //   href: '/exec-application',
+    //   desc: 'Exec Application',
+    // },
     // {
     //   href: '/dsc',
     //   desc: 'DSC',


### PR DESCRIPTION
# Changes 🛠

## What does this PR do?
Comments out Executive Applications from the navbar and the router

## Screenshots 🖼

### Before
![image](https://github.com/BrockCSC/brockcsc.github.io/assets/117380848/c86a4abd-4537-4168-97e4-1dbaa73d2f4b)

### After
![image](https://github.com/BrockCSC/brockcsc.github.io/assets/117380848/c282f525-2f9f-4025-bc04-19a1ae538e48)

## Any new npm dependencies?

NO

# Testing 🧪

Changes from the latest PR are deployed to https://brockcsc-pr.web.app once the checks are complete. Can use this for testing.

### Any other info needed for testing?

NO
