### PR TITLE
Hotfix/image cover

### DIFF
--- a/src/app/views/team/team-preview/team-preview.component.scss
+++ b/src/app/views/team/team-preview/team-preview.component.scss
@@ -37,6 +37,7 @@ $img-size: 40px;
   display: flex;
   align-items: center;
   .exec-avatar {
+    object-fit: cover;
     border-radius: 100%;
     width: $img-size;
     height: $img-size;


### PR DESCRIPTION
# Changes 🛠
Fixed the preview of exec icons on the homepage of the website

## What does this PR do?
Previously exec icons were stretched on the homepage, now they are fixed. 

## Screenshots 🖼

### Before
![Screenshot 2024-11-06 120526](https://github.com/user-attachments/assets/265c34a9-3961-41ea-9d0e-b16250fc5c05)

### After
<img width="341" alt="image" src="https://github.com/user-attachments/assets/6bf468b9-ca09-4178-88fd-0c3aecdae49e">

## Any new npm dependencies?

NO

# Testing 🧪

Changes from the latest PR are deployed to https://brockcsc-pr.web.app once the checks are complete. Can use this for testing.

### Any other info needed for testing?

NO
