### PR TITLE
Update competition page

### DIFF
--- a/.github/workflows/brockcsc-test-deploy.yml
+++ b/.github/workflows/brockcsc-test-deploy.yml
@@ -10,13 +10,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@master
       - name: Install Dependencies
         run: npm install
       - name: Build
         run: npm run build:dev
       - name: Archive Production Artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@master
         with:
           name: dist
           path: dist
@@ -26,14 +26,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@master
       - name: Download Artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@master
         with:
           name: dist
           path: dist
       - name: Deploy to Firebase
-        uses: w9jds/firebase-action@v13.4.0
+        uses: w9jds/firebase-action@master
         with:
           args: deploy --only hosting:brockcsc-test
         env:

--- a/.github/workflows/brockcsc-test-deploy.yml
+++ b/.github/workflows/brockcsc-test-deploy.yml
@@ -37,4 +37,4 @@ jobs:
         with:
           args: deploy --only hosting:brockcsc-test
         env:
-          FIREBASE_TOKEN: ${{ secrets.FIREBASE_TOKEN_BROCKCSC_TEST }}
+          GCP_SA_KEY: ${{ secrets.GCP_SA_KEY_BROCKCSC_TEST }}

--- a/.github/workflows/development-pr-test.yml
+++ b/.github/workflows/development-pr-test.yml
@@ -10,13 +10,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@master
       - name: Install Dependencies
         run: npm install
       - name: Build
         run: npm run build:dev
       - name: Archive Production Artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@master
         with:
           name: dist
           path: dist
@@ -26,14 +26,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@master
       - name: Download Artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@master
         with:
           name: dist
           path: dist
       - name: Deploy to Firebase
-        uses: w9jds/firebase-action@v13.4.0
+        uses: w9jds/firebase-action@master
         with:
           args: deploy --only hosting:brockcsc-pr
         env:

--- a/src/app/views/icpc/icpc.component.html
+++ b/src/app/views/icpc/icpc.component.html
@@ -1,51 +1,37 @@
 <div class="main-container">
-  Updated: 2024/10/25
-  <h2>Team Mini Competitions - Web</h2>
-  You are tasked with building an online flight booking website. (eg. Expedia) A
-  portal to manage airlines/flights, and a front-facing portal for customers to
-  book tickets.<br />
+  Updated: 2025/1/28
+  <h2>Team Mini Competitions</h2>
+  You are tasked with building an online investment platform e.g., QuestTrade A
+  portal to manage investments manually or via investment broker / AI.<br />
+  You will be using a fake stock market for investments, create and hosted
+  explicitly for this contest. <br />
+  Do not abuse the API in any way.<br />
   <br />
-  <b>November Registration: </b>
-  <a href="https://forms.gle/f6Xsu3kW3GtmrW9h6">Google Form</a>
+  <b>January Registration: </b>
+  <a
+    href="https://docs.google.com/forms/d/e/1FAIpQLSdcszcEIn2MdjfFIhlv1mucCxdnM2Fs0PnSEHreNds1LWt7Rw/viewform"
+    >Google Form</a
+  >
 
   <h3>Requirement(s)</h3>
   <ul>
+    <li>Users should be able to register an account</li>
+    <li>Customers should be able to review stock information</li>
     <li>
-      Customers should be able to see a list of flights from airport A to
-      airport B.
+      Customers should be able to review portfolio information and notifications
+      about owned stocks and markets
     </li>
     <li>
-      Customers should be able to see a list of flights for a selected date.
+      Customers should be able to add and remove money from their portfolio
     </li>
     <li>
-      Customers should be able to filter a list of flights by at least 1 other
-      criteria. (eg. airlines, price range)
+      Customers should be able to choose between a self-managed account (manual
+      investing) and an automated account (transactions done by
+      AI/someone/something else) when creating their portfolio
     </li>
     <li>
-      Customers should be able to sort a list of flights by at least 1 criteria
-      in both ascending and descending order. (eg. travel time, price)
-    </li>
-    <li>Customers should be able to book a flight with available seats.</li>
-    <li>
-      Customers should be able to cancel their booked flight at most 24hrs
-      before departure.
-    </li>
-    <li>Customers should be able to see their flight ticket information.</li>
-    <li>
-      Customers should be able to leave a review for a previous flight they’ve
-      went on.
-    </li>
-    <li>
-      (Optional) Customers should be notified by email of a change in flight
-      information (eg. postponed, canceled).
-    </li>
-    <li>Airlines should be able to add new flights.</li>
-    <li>Airlines should be able to postpone their registered flights.</li>
-    <li>Airlines should be able to cancel their registered flights.</li>
-    <li>Users should be able to register a Customer account.</li>
-    <li>
-      Users should be able to register an Airline account on behalf of an
-      airline.
+      Customers should be able to purchase and sell stock shares from the funds
+      in their portfolio, during active market trading hours
     </li>
   </ul>
 
@@ -57,7 +43,7 @@
     </li>
     <li>
       For any questions about what other information may constitute PII, consult
-      Gideon or Nikolas.
+      Nikolas.
     </li>
     <li>
       Extra points for unlisted novel requirements are assigned subject to the
@@ -65,8 +51,8 @@
     </li>
   </ul>
   <i
-    >PII includes, but is not limited to: name, email address, date of birth,
+    >PII includes, but is not limited to name, email address, date of birth,
     credit card information, student number, address, phone number, passport
-    information, driver’s license information etc.
-  </i>
+    information, driver's license information etc.</i
+  >
 </div>


### PR DESCRIPTION
# Changes 🛠

## What does this PR do?
Updates the ICPC competition page with the new Winter 2025 investment platform competition details, including:
- Updated competition task description for building an online investment platform
- Added registration link for January
- Listed detailed requirements for the platform functionality

## Screenshots 🖼

### Before
<img width="1267" alt="image" src="https://github.com/user-attachments/assets/9cb15220-6b89-4f5d-88e3-1121c39f79e8" />

### After
The page now shows:
- Updated competition task for building an investment platform (QuestTrade-like)
- Clear requirements for user registration, stock information, portfolio management
- January registration Google Form link
<img width="1268" alt="image" src="https://github.com/user-attachments/assets/24f4ac9f-6011-4d47-8905-ed1a89cfaa3f" />

## Any new npm dependencies?

NO

# Testing 🧪

Changes from the latest PR are deployed to https://brockcsc-pr.web.app once the checks are complete. Can use this for testing.

### Any other info needed for testing?
- Verify that the Google Form link is accessible