### PR TITLE
Add header id's for markdown content in guide component

### DIFF
--- a/src/app/views/guide/guide.component.html
+++ b/src/app/views/guide/guide.component.html
@@ -6,5 +6,9 @@
       >Contribute to this guide</a
     >
   </div>
-  <div markdown [src]="'assets/cs-guide.md'" class="markdown-content"></div>
+  <markdown
+    [src]="'assets/cs-guide.md'"
+    class="markdown-content"
+    (load)="addHeaderIds()"
+  ></markdown>
 </div>

--- a/src/app/views/guide/guide.component.scss
+++ b/src/app/views/guide/guide.component.scss
@@ -7,6 +7,13 @@
   margin-bottom: 3rem;
 }
 
+::ng-deep .markdown-content {
+  h1,
+  h2 {
+    scroll-margin-top: 6.375rem;
+  }
+}
+
 ::ng-deep .markdown-content table {
   display: block;
   max-width: 100%;

--- a/src/app/views/guide/guide.component.ts
+++ b/src/app/views/guide/guide.component.ts
@@ -1,4 +1,4 @@
-import { Component } from '@angular/core';
+import { Component, AfterViewInit } from '@angular/core';
 import { MarkdownComponent } from 'ngx-markdown';
 import { ButtonDirective } from '../../shared/button/button.directive';
 
@@ -9,4 +9,29 @@ import { ButtonDirective } from '../../shared/button/button.directive';
   standalone: true,
   imports: [ButtonDirective, MarkdownComponent],
 })
-export class GuideComponent {}
+export class GuideComponent implements AfterViewInit {
+  ngAfterViewInit() {
+    // Add IDs after view init in case content was loaded before the load event
+    this.addHeaderIds();
+  }
+
+  addHeaderIds() {
+    const content = document.querySelector('.markdown-content');
+    if (!content) return;
+
+    // Find all h1 and h2 elements
+    const headers = content.querySelectorAll('h1, h2');
+
+    headers.forEach((header) => {
+      // Get the text content and create an ID
+      const text = header.textContent || '';
+      const id = text
+        .toLowerCase()
+        .replace(/[^a-z0-9]+/g, '-') // Replace non-alphanumeric chars with hyphens
+        .replace(/^-+|-+$/g, ''); // Remove leading/trailing hyphens
+
+      // Set the ID
+      header.id = id;
+    });
+  }
+}


### PR DESCRIPTION
# Changes 🛠

## What does this PR do?

This PR fixes the table of contents navigation in the CS Guide by:
1. Adding automatic header ID generation:
    - Created script in GuideComponent to generate IDs for all h1 and h2 elements
    - IDs are created from header text (lowercase, hyphenated)
    - Added markdown (load) event listener to ensure IDs are set after content renders
2. Fixed header visibility when navigating:
    - Added scroll-margin-top: 6.375rem to prevent headers being hidden behind navbar
    - Value accounts for navbar height (5.375rem) + padding (1rem)

The table of contents section now works.

## Screenshots 🖼

### Before
<img width="1345" alt="Screenshot 2025-02-28 at 10 02 20 AM" src="https://github.com/user-attachments/assets/722b1890-b101-4b20-85c8-5cb0e4bc8232" />

### After
<img width="1345" alt="Screenshot 2025-02-28 at 10 02 31 AM" src="https://github.com/user-attachments/assets/299a6b71-8e5c-47f7-9516-86d9b691fe56" />

## Any new npm dependencies?

NO

# Testing 🧪

Changes from the latest PR are deployed to https://brockcsc-pr.web.app once the checks are complete. Can use this for testing.

### Any other info needed for testing?

NO
