### PR TITLE
Update home component content & remove services section

### DIFF
--- a/src/app/core/nav/nav.component.html
+++ b/src/app/core/nav/nav.component.html
@@ -34,14 +34,24 @@
           </button>
         </a>
       </span>
-      <a
-        csclink
-        *ngFor="let link of links"
-        [routerLink]="link.href"
-        routerLinkActive="active-link"
-        [title]="link.desc"
-        >{{ link.desc }}</a
-      >
+      <ng-container *ngFor="let link of links">
+        <a
+          csclink
+          *ngIf="!link.href.startsWith('http')"
+          [routerLink]="link.href"
+          routerLinkActive="active-link"
+          [title]="link.desc"
+          >{{ link.desc }}</a
+        >
+        <a
+          csclink
+          *ngIf="link.href.startsWith('http')"
+          [href]="link.href"
+          rel="noopener noreferrer"
+          [title]="link.desc"
+          >{{ link.desc }}</a
+        >
+      </ng-container>
       <a
         csclink
         *ngIf="linkAdmin.visible"
@@ -85,13 +95,24 @@
     >
       <div class="nav-overlay-content">
         <a routerLink="/home" (click)="toggleOverlayMenu()">Home</a>
-        <a
-          *ngFor="let link of links"
-          [routerLink]="link.href"
-          (click)="toggleOverlayMenu()"
-          [title]="link.desc"
-          >{{ link.desc }}</a
-        >
+        <ng-container *ngFor="let link of links">
+          <a
+            *ngIf="!link.href.startsWith('http')"
+            [routerLink]="link.href"
+            (click)="toggleOverlayMenu()"
+            [title]="link.desc"
+            >{{ link.desc }}</a
+          >
+          <a
+            *ngIf="link.href.startsWith('http')"
+            [href]="link.href"
+            target="_blank"
+            rel="noopener noreferrer"
+            (click)="toggleOverlayMenu()"
+            [title]="link.desc"
+            >{{ link.desc }}</a
+          >
+        </ng-container>
         <a
           *ngIf="linkAdmin.visible"
           [routerLink]="linkAdmin.href"

--- a/src/app/core/nav/nav.component.ts
+++ b/src/app/core/nav/nav.component.ts
@@ -75,6 +75,7 @@ export class NavComponent implements OnInit {
     {
       href: 'https://volunteer.brockcsc.ca',
       desc: 'Volunteer',
+      isExternal: true,
     },
     {
       href: '/contact',
@@ -142,4 +143,5 @@ interface NavLink {
   href: string;
   desc: string;
   visible?: boolean;
+  isExternal?: boolean;
 }

--- a/src/app/views/home/home.component.html
+++ b/src/app/views/home/home.component.html
@@ -53,9 +53,7 @@
     <h2 class="csc-header">About us</h2>
     <div class="row">
       <div class="col-8 col-m-12">
-        <p>
-          We are the Brock Computer Science Club, a local chapter of the ACM.
-        </p>
+        <p>We are the Brock Computer Science Club, a BUSU ratified club.</p>
         <p>
           Our goal is to provide a community for all individuals who are
           interested in Computer Science at Brock University.
@@ -78,7 +76,7 @@
         target="_blank"
         >Read the club charter</a
       >
-      <br />
+      <br /><br />
       <a
         href="https://drive.google.com/file/d/1CPO4Aia-bTdzwhnwBwIMbIGwccr8Ss1Q/view?usp=sharing"
         class="csc-header"
@@ -99,27 +97,6 @@
         data-link-color="#AA3B3B"
         href="https://twitter.com/BrockuCSC"
       ></a>
-    </div>
-  </div>
-</section>
-<section id="csc-services">
-  <div class="row">
-    <div class="container">
-      <h2 class="csc-header">Services</h2>
-      <div class="csc-services-content">
-        <div class="row" *ngFor="let service of services">
-          <div class="column-left">
-            <i class="material-icons">{{ service.icon }}</i
-            ><span class="csc-icon-title">{{ service.title }}</span>
-          </div>
-          <div class="column-right">
-            <p>{{ service.desc }}</p>
-          </div>
-        </div>
-      </div>
-      <a routerLink="/services" class="csc-header"
-        >See more about our services</a
-      >
     </div>
   </div>
 </section>


### PR DESCRIPTION
# Changes 🛠

## What does this PR do?

This PR updates the home component content and removes the unused services section:

- Updates the "About us" description to reflect that the club is "a BUSU ratified club" instead of "a local chapter of the ACM"
- Removes the entire services section from the home page, including:
  - Services header
  - Dynamic services content display
  - "See more about our services" link
- Adds extra spacing after the club charter link for better visual separation

## Screenshots 🖼

### Before

The home page previously included a services section that displayed various club services with icons and descriptions, and described the club as "a local chapter of the ACM".

### After

The home page now has a cleaner layout without the services section, and correctly identifies the club as "a BUSU ratified club" with improved spacing in the about section.

## Any new npm dependencies?

NO

# Testing 🧪

Changes from the latest PR are deployed to https://brockcsc-pr.web.app once the checks are complete. Can use this for testing.

### Any other info needed for testing?

NO
