### PR TITLE
content: remove icpc from links page

### DIFF
--- a/src/app/views/links/links.component.html
+++ b/src/app/views/links/links.component.html
@@ -7,13 +7,6 @@
   <div class="links-list">
     <button
       class="link-button"
-      (click)="openLink('https://brockcsc.ca/events/-Oa1cJ_JZxT1FeYCp3uy')"
-    >
-      <img src="assets/icons/icpc.png" alt="ICPC Logo" class="icon" />
-      <span>ICPC Qualifiers Registration</span>
-    </button>
-    <button
-      class="link-button"
       (click)="openLink('https://discord.gg/qsctEK2')"
     >
       <img src="assets/icons/discord.svg" alt="Discord icon" class="icon" />


### PR DESCRIPTION
# Changes 🛠
Remove ICPC registration link from the /links page

## What does this PR do?
Remove ICPC registration link from /links page

## Screenshots 🖼

|Before|After|
|-|-|
|<img width="1512" height="877" alt="image" src="https://github.com/user-attachments/assets/dfe1cf23-05e4-4367-8d82-91c13018807a" />|<img width="1512" height="879" alt="image" src="https://github.com/user-attachments/assets/b49e0175-73ff-4e57-bd51-b72215b03be5" />|

## Any new npm dependencies?

NO

# Testing 🧪

Changes from the latest PR are deployed to https://brockcsc-pr.web.app once the checks are complete. Can use this for testing.

### Any other info needed for testing?

NO
